### PR TITLE
Edit-database_design

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ https://drive.google.com/file/d/1LigQ5Lw3vgyLxmpJne4sSXfXoEVRXuNK/view?usp=shari
 |nickname|string|null: false, unique: true|
 |email|string|null: false, unique: true|
 |password|string|null: false|
-|family_name|string|null: false|
-|first_name|string|null: false|
-|family_name_kana|string|null: false|
-|first_name_kana|string|null: false|
 |introduction|string|null: false|
 |birthday|date|null: false|
 |address_id|integer|null: false|
@@ -61,16 +57,19 @@ https://drive.google.com/file/d/1LigQ5Lw3vgyLxmpJne4sSXfXoEVRXuNK/view?usp=shari
 - has_many :deals, dependent: :destroy
 - has_one :address, dependent: :destroy
 
-##addressesテーブル
+## addressesテーブル
 |Column|Type|Options|
 |------|----|-------|
+|family_name|string|null: false|
+|first_name|string|null: false|
+|family_name_kana|string|null: false|
+|first_name_kana|string|null: false|
 |postal_code|string|null: false|
 |prefecture|string|null: false|
 |city|string|null: false|
 |street_number|string|null: false|
 |building|string|
 |telephone|integer|
-|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ https://drive.google.com/file/d/1LigQ5Lw3vgyLxmpJne4sSXfXoEVRXuNK/view?usp=shari
 |nickname|string|null: false, unique: true|
 |email|string|null: false, unique: true|
 |password|string|null: false|
+|family_name|string|null: false|
+|first_name|string|null: false|
+|family_name_kana|string|null: false|
+|first_name_kana|string|null: false|
 |introduction|string|null: false|
 |birthday|date|null: false|
 |address_id|integer|null: false|
@@ -60,16 +64,13 @@ https://drive.google.com/file/d/1LigQ5Lw3vgyLxmpJne4sSXfXoEVRXuNK/view?usp=shari
 ## addressesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|family_name|string|null: false|
-|first_name|string|null: false|
-|family_name_kana|string|null: false|
-|first_name_kana|string|null: false|
 |postal_code|string|null: false|
 |prefecture|string|null: false|
 |city|string|null: false|
 |street_number|string|null: false|
 |building|string|
 |telephone|integer|
+|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user


### PR DESCRIPTION
# what
database設計の変更

# why
メルカリの特性上、アカウント情報の登録のあと住所登録があり、usersテーブルとadressesのテーブルを分けたとき、family_nameやfirst_nameは住所登録の際に登録する内容であることから、明らかにadressesテーブル情報であり、設計上familynameやfirstnameの情報がusersテーブルにあることは余計な混乱を招くため。
また銀行の口座情報登録なども新規に入力させ”住所の名前”という項目と照らし合わせていることから、将来的な機能の追加でもメルカリに合わせてadressesテーブルに保存した方がいいと考えたため。